### PR TITLE
fix: types/croner - `date` -> `Date`

### DIFF
--- a/dist/croner.cjs
+++ b/dist/croner.cjs
@@ -16,9 +16,9 @@
 	 *                                                 (for example) will return local time in new york, but getUTCHours()
 	 *                                                 will return something irrelevant.
 	 * 
-	 * @param {date} date - Input date
+	 * @param {Date} date - Input date
 	 * @param {string} tzString - Timezone string in Europe/Stockholm format
-	 * @returns {date}
+	 * @returns {Date}
 	 */
 	function convertTZ(date, tzString) {
 		return new Date(date.toLocaleString("en-US", {timeZone: tzString}));   
@@ -751,7 +751,7 @@
 	 * Cron entrypoint
 	 * 
 	 * @constructor
-	 * @param {string|date} pattern - Input pattern, input date, or input ISO 8601 time string
+	 * @param {string|Date} pattern - Input pattern, input date, or input ISO 8601 time string
 	 * @param {CronOptions|Function} [options] - Options
 	 * @param {Function} [func] - Function to be run each iteration of pattern
 	 * @returns {Cron}

--- a/docs/Cron.html
+++ b/docs/Cron.html
@@ -169,7 +169,7 @@
     |
 
     <span class="param-type">
-      date
+      Date
     </span>
 
     

--- a/docs/croner.js.html
+++ b/docs/croner.js.html
@@ -182,7 +182,7 @@ const maxDelay = Math.pow(2, 32 - 1) - 1;
  * Cron entrypoint
  * 
  * @constructor
- * @param {string|date} pattern - Input pattern, input date, or input ISO 8601 time string
+ * @param {string|Date} pattern - Input pattern, input date, or input ISO 8601 time string
  * @param {CronOptions|Function} [options] - Options
  * @param {Function} [func] - Function to be run each iteration of pattern
  * @returns {Cron}

--- a/docs/global.html
+++ b/docs/global.html
@@ -268,7 +268,7 @@ int to keep the behaviour concistent.</p>
       </svg>
     </a>
     <h4 class="name" id="convertTZ">
-      <span class="type-signature"></span>.convertTZ<span class="signature">(date, tzString)</span><span class="type-signature"> &rarr; {date}</span>
+      <span class="type-signature"></span>.convertTZ<span class="signature">(date, tzString)</span><span class="type-signature"> &rarr; {Date}</span>
     </h4>
   </span>
 
@@ -303,7 +303,7 @@ will return something irrelevant.</p>
                <code>date</code>
                <em>(
     <span class="param-type">
-      date
+      Date
     </span>
 
     

--- a/docs/timezone.js.html
+++ b/docs/timezone.js.html
@@ -134,9 +134,9 @@
  *                                                 (for example) will return local time in new york, but getUTCHours()
  *                                                 will return something irrelevant.
  * 
- * @param {date} date - Input date
+ * @param {Date} date - Input date
  * @param {string} tzString - Timezone string in Europe/Stockholm format
- * @returns {date}
+ * @returns {Date}
  */
 function convertTZ(date, tzString) {
 	return new Date(date.toLocaleString("en-US", {timeZone: tzString}));   

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,14 +38,14 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -423,12 +423,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.1.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -436,10 +436,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -515,23 +515,23 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1080,9 +1080,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1292,9 +1292,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.67.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
-      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
+      "version": "2.67.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
+      "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1669,14 +1669,14 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-      "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
+      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.2.0",
+        "espree": "^9.3.1",
         "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
@@ -1970,12 +1970,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
+      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.0.5",
+        "@eslint/eslintrc": "^1.1.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1983,10 +1983,10 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.0",
+        "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.2.0",
-        "espree": "^9.3.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2013,9 +2013,9 @@
       }
     },
     "eslint-scope": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-      "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
@@ -2040,20 +2040,20 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-      "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
     "espree": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-      "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",
         "acorn-jsx": "^5.3.1",
-        "eslint-visitor-keys": "^3.1.0"
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "esquery": {
@@ -2471,9 +2471,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.1.tgz",
+      "integrity": "sha512-reLxBcKUPNBnc/sVtAbxgRVFSegoGeLaSjmphNhcwcolhYLRgtJscn5mRl6YRZNQv40Y7P6JM2YhSIsbL9OB5A==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -2620,9 +2620,9 @@
       }
     },
     "rollup": {
-      "version": "2.67.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.1.tgz",
-      "integrity": "sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==",
+      "version": "2.67.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.2.tgz",
+      "integrity": "sha512-hoEiBWwZtf1QdK3jZIq59L0FJj4Fiv4RplCO4pvCRC86qsoFurWB4hKQIjoRf3WvJmk5UZ9b0y5ton+62fC7Tw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/src/croner.js
+++ b/src/croner.js
@@ -58,7 +58,7 @@ const maxDelay = Math.pow(2, 32 - 1) - 1;
  * Cron entrypoint
  * 
  * @constructor
- * @param {string|date} pattern - Input pattern, input date, or input ISO 8601 time string
+ * @param {string|Date} pattern - Input pattern, input date, or input ISO 8601 time string
  * @param {CronOptions|Function} [options] - Options
  * @param {Function} [func] - Function to be run each iteration of pattern
  * @returns {Cron}

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -10,9 +10,9 @@
  *                                                 (for example) will return local time in new york, but getUTCHours()
  *                                                 will return something irrelevant.
  * 
- * @param {date} date - Input date
+ * @param {Date} date - Input date
  * @param {string} tzString - Timezone string in Europe/Stockholm format
- * @returns {date}
+ * @returns {Date}
  */
 function convertTZ(date, tzString) {
 	return new Date(date.toLocaleString("en-US", {timeZone: tzString}));   

--- a/types/croner.d.ts
+++ b/types/croner.d.ts
@@ -40,23 +40,23 @@ export type CronOptions = {
  * Cron entrypoint
  *
  * @constructor
- * @param {string|date} pattern - Input pattern, input date, or input ISO 8601 time string
+ * @param {string|Date} pattern - Input pattern, input date, or input ISO 8601 time string
  * @param {CronOptions|Function} [options] - Options
  * @param {Function} [func] - Function to be run each iteration of pattern
  * @returns {Cron}
  */
-export function Cron(pattern: string | date, options?: CronOptions | Function, func?: Function): Cron;
+export function Cron(pattern: string | Date, options?: CronOptions | Function, func?: Function): Cron;
 export class Cron {
     /**
      * Cron entrypoint
      *
      * @constructor
-     * @param {string|date} pattern - Input pattern, input date, or input ISO 8601 time string
+     * @param {string|Date} pattern - Input pattern, input date, or input ISO 8601 time string
      * @param {CronOptions|Function} [options] - Options
      * @param {Function} [func] - Function to be run each iteration of pattern
      * @returns {Cron}
      */
-    constructor(pattern: string | date, options?: CronOptions | Function, func?: Function);
+    constructor(pattern: string | Date, options?: CronOptions | Function, func?: Function);
     /** @type {CronOptions} */
     options: CronOptions;
     once: CronPattern;

--- a/types/timezone.d.ts
+++ b/types/timezone.d.ts
@@ -11,8 +11,8 @@ export default convertTZ;
  *                                                 (for example) will return local time in new york, but getUTCHours()
  *                                                 will return something irrelevant.
  *
- * @param {date} date - Input date
+ * @param {Date} date - Input date
  * @param {string} tzString - Timezone string in Europe/Stockholm format
- * @returns {date}
+ * @returns {Date}
  */
-declare function convertTZ(date: any, tzString: string): any;
+declare function convertTZ(date: Date, tzString: string): Date;


### PR DESCRIPTION
`tsc` would fail with:
```
node_modules/croner/types/croner.d.ts(48,40): error TS2552: Cannot find name 'date'. Did you mean 'Date'?
node_modules/croner/types/croner.d.ts(59,35): error TS2552: Cannot find name 'date'. Did you mean 'Date'?
```