### PR TITLE
feat: generic context typing

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -47,7 +47,7 @@ const RecursionSteps: RecursionStep[] = [
  * @param d Input date, if using string representation ISO 8001 (2015-11-24T19:40:00) local timezone is expected
  * @param tz String representation of target timezone in Europe/Stockholm format, or a number representing offset in minutes.
  */
-class CronDate {
+class CronDate<T = undefined> {
   tz: string | number | undefined;
 
   /**
@@ -90,7 +90,7 @@ class CronDate {
    */
   year!: number;
 
-  constructor(d?: CronDate | Date | string | null, tz?: string | number) {
+  constructor(d?: CronDate<T> | Date | string | null, tz?: string | number) {
     /**
      * TimeZone
      * @type {string|number|undefined}
@@ -205,7 +205,7 @@ class CronDate {
    *
    * @param {CronDate} d - Input date
    */
-  private fromCronDate(d: CronDate) {
+  private fromCronDate(d: CronDate<T>) {
     this.tz = d.tz;
     this.year = d.year;
     this.month = d.month;
@@ -267,7 +267,7 @@ class CronDate {
    * Find next match of current part
    */
   private findNext(
-    options: CronOptions,
+    options: CronOptions<T>,
     target: RecursionTarget,
     pattern: CronPattern,
     offset: number,
@@ -359,7 +359,11 @@ class CronDate {
    *
    * @private
    */
-  private recurse(pattern: CronPattern, options: CronOptions, doing: number): CronDate | null {
+  private recurse(
+    pattern: CronPattern,
+    options: CronOptions<T>,
+    doing: number,
+  ): CronDate<T> | null {
     // Find next month (or whichever part we're at)
     const res = this.findNext(options, RecursionSteps[doing][0], pattern, RecursionSteps[doing][2]);
 
@@ -412,9 +416,9 @@ class CronDate {
    */
   public increment(
     pattern: CronPattern,
-    options: CronOptions,
+    options: CronOptions<T>,
     hasPreviousRun: boolean,
-  ): CronDate | null {
+  ): CronDate<T> | null {
     // Move to next second, or increment according to minimum interval indicated by option `interval: x`
     // Do not increment a full interval if this is the very first run
     this.second += (options.interval !== undefined && options.interval > 1 && hasPreviousRun)

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,7 +9,7 @@ type ProtectCallbackFn = (job: Cron) => void;
  *
  * @interface
  */
-interface CronOptions {
+interface CronOptions<T = undefined> {
   /**
    * The name of the cron job. If provided, the job will be added to the
    * `scheduledJobs` array, allowing it to be accessed by name.
@@ -64,12 +64,12 @@ interface CronOptions {
   /**
    * The date and time at which the job should start running.
    */
-  startAt?: string | Date | CronDate;
+  startAt?: string | Date | CronDate<T>;
 
   /**
    * The date and time at which the job should stop running.
    */
-  stopAt?: string | Date | CronDate;
+  stopAt?: string | Date | CronDate<T>;
 
   /**
    * The timezone for the cron job.
@@ -90,7 +90,7 @@ interface CronOptions {
   /**
    * An optional context object that will be passed to the job function.
    */
-  context?: unknown;
+  context?: T;
 }
 
 /**
@@ -100,7 +100,7 @@ interface CronOptions {
  * @returns The processed and validated cron options.
  * @throws {Error} If any of the options are invalid.
  */
-function CronOptionsHandler(options?: CronOptions): CronOptions {
+function CronOptionsHandler<T = undefined>(options?: CronOptions<T>): CronOptions<T> {
   if (options === void 0) {
     options = {};
   }

--- a/test/croner.test.ts
+++ b/test/croner.test.ts
@@ -103,6 +103,7 @@ test("Too high hours minute should throw", function () {
     scheduler.nextRun();
   });
 });
+
 test(
   "Context is passed",
   //@ts-ignore
@@ -270,6 +271,7 @@ test("Croner should increment days", function () {
   assertEquals(true, runs[1] < runs[2]);
   assertEquals(true, runs[2] < runs[3]);
 });
+
 test("Croner should increment months", function () {
   let runs = new Cron("0 0 0 1 * *").nextRuns(4);
   assertEquals(true, runs[0] < runs[1]);
@@ -345,6 +347,7 @@ test("Impossible combination should result in null (non legacy mode)", function 
   let impossible = new Cron("0 0 0 30 2 6", { legacyMode: false }).nextRun(new Date(1634076000000));
   assertEquals(null, impossible);
 });
+
 test(
   "currentRun() and previousRun() should be set at correct points in time",
   //@ts-ignore
@@ -361,6 +364,7 @@ test(
     }, 2000);
   }),
 );
+
 test(
   "scheduled job should not stop on unhandled error with option catch: true",
   //@ts-ignore
@@ -376,6 +380,7 @@ test(
     });
   }),
 );
+
 test(
   "scheduled job should execute callback on unhandled error with option catch: callback()",
   //@ts-ignore
@@ -480,6 +485,7 @@ test(
     }
   }),
 );
+
 test("sanity check start stop resume", function () {
   let job = new Cron("* * * 1 11 4", () => {});
   assertEquals(job.isRunning(), true);
@@ -524,6 +530,7 @@ test("previous run time should be null if not yet executed", function () {
   assertEquals(result, null);
   job.stop();
 });
+
 test(
   "previous run time should be set if executed",
   //@ts-ignore
@@ -894,7 +901,7 @@ test(
       }
     }, 2100);
   },
-  { waitForCallback: true, timeout: 3000 },
+  { waitForCallback: true, timeout: 5000 },
 );
 
 test(
@@ -919,6 +926,7 @@ test(
   },
   { waitForCallback: true, timeout: 5000 },
 );
+
 test(
   "Job should be working after 1500 ms",
   (context, done) => {
@@ -939,6 +947,7 @@ test(
   },
   { waitForCallback: true, timeout: 4000 },
 );
+
 test(
   "Job should not be working after 1500 ms",
   (context, done) => {
@@ -957,8 +966,9 @@ test(
       }
     }, 3500);
   },
-  { waitForCallback: true, timeout: 4000 },
+  { waitForCallback: true, timeout: 6000 },
 );
+
 test("Fire-once should be supported by ISO 8601 string, past and .nextRun() should return null", function () {
   let scheduler0 = new Cron("2020-01-01T00:00:00");
   assertEquals(scheduler0.nextRun(), null);


### PR DESCRIPTION
Since latest changes the context is typed to "unknown" and i have to type convert all my context accesses.

e.g.

```TS
new Cron(...., { context: { test: 'bal' } }, (job, context) => (context as ...).bla)
```

when i try to directly type the context in the callback param definition i can not, because it is fixed typed as "unknown"

now you are be able to explicit type the context via generics or it will be implicit set how you define your context.

The sad part -> since the scheduledJobs list is "untyped" because it is globally, i have to allow "any"-type for the definition of scheduledJobs.

