### PR TITLE
Update copyright year to 2026

### DIFF
--- a/src/croner.ts
+++ b/src/croner.ts
@@ -9,7 +9,7 @@
 
   License:
 
-	Copyright (c) 2015-2024 Hexagon <github.com/Hexagon>
+	Copyright (c) 2015-2026 Hexagon <github.com/Hexagon>
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Minor housekeeping: updates the copyright year in the license header from 2024 to 2026.

No functional changes.